### PR TITLE
Bugfix: Добавил цвет отдельно для статус бара

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -10,5 +10,7 @@
         <item name="colorOnBackgroundPrimary">@color/white</item>
         <item name="colorTextField">@color/gray</item>
         <item name="colorHintTextField">@color/white</item>
+        <item name="android:statusBarColor">@color/black</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,6 +10,8 @@
         <item name="colorOnBackgroundPrimary">@color/black</item>
         <item name="colorTextField">@color/light_gray</item>
         <item name="colorHintTextField">@color/gray</item>
+        <item name="android:statusBarColor">@color/white</item>
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
     <style name="Theme.PracticumAndroidDiploma" parent="Base.Theme.PracticumAndroidDiploma" />


### PR DESCRIPTION
### Ожидаемое поведение:

_Светлая тема_
<img width="752" height="68" alt="firefox_260324_171" src="https://github.com/user-attachments/assets/296a2b4d-d59a-45be-9152-453e653cb32d" />

_Темная тема_
<img width="1058" height="86" alt="firefox_260324_172" src="https://github.com/user-attachments/assets/22e359e2-4fe2-4962-8450-ecd16837fbd0" />

### Действительное поведение:

_Светлая тема_
<img width="340" height="64" alt="studio64_260324_169" src="https://github.com/user-attachments/assets/54949b5e-ac8b-4f41-8cac-72de7c253e05" />
_Темная тема_
<img width="344" height="74" alt="studio64_260324_170" src="https://github.com/user-attachments/assets/0dd65010-9944-457b-99cc-8226a3ca73ef" />

### Решение

В теме приложения теперь уточняется цвет статус бара и отображение значков на нем

_Светлая тема_
<img width="335" height="58" alt="studio64_260324_173" src="https://github.com/user-attachments/assets/b297270b-8255-4e33-b361-2e336e7a5718" />

_Темная тема_
<img width="342" height="55" alt="studio64_260324_174" src="https://github.com/user-attachments/assets/03da4184-00ea-4591-845a-76ab94bdf76d" />



