### PR TITLE
Bugfix: атрибут background применялся к нежелательным системным элементам

### DIFF
--- a/app/src/main/res/layout/activity_root.xml
+++ b/app/src/main/res/layout/activity_root.xml
@@ -33,7 +33,7 @@
         android:id="@+id/bottomNavigationView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-
+        android:background="?attr/colorBackgroundPrimary"
         app:itemActiveIndicatorStyle="@null"
 
         app:itemGravity="center"

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -11,6 +11,7 @@
         android:id="@+id/favoriteHeader"
         android:layout_width="match_parent"
         android:layout_height="64dp"
+        app:cardBackgroundColor="?attr/colorBackgroundPrimary"
         app:cardElevation="0dp"
         app:cardMaxElevation="0dp"
         app:layout_constraintTop_toTopOf="parent">

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -11,6 +11,7 @@
         android:id="@+id/searchHeader"
         android:layout_width="match_parent"
         android:layout_height="64dp"
+        app:cardBackgroundColor="?attr/colorBackgroundPrimary"
         app:cardElevation="0dp"
         app:cardMaxElevation="0dp"
         app:layout_constraintTop_toTopOf="parent">
@@ -64,7 +65,8 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:background="?attr/colorBackgroundPrimary">
 
             <EditText
                 android:id="@+id/searchInput"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -5,7 +5,7 @@
         <item name="colorPrimary">@color/blue</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Цвет активити по умолчанию -->
-        <item name="android:background">@color/black</item>
+        <item name="android:windowBackground">@color/black</item>
         <item name="colorBackgroundPrimary">@color/black</item>
         <item name="colorOnBackgroundPrimary">@color/white</item>
         <item name="colorTextField">@color/gray</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,7 +5,7 @@
         <item name="colorPrimary">@color/blue</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Цвет активити по умолчанию -->
-        <item name="android:background">@color/white</item>
+        <item name="android:windowBackground">@color/white</item>
         <item name="colorBackgroundPrimary">@color/white</item>
         <item name="colorOnBackgroundPrimary">@color/black</item>
         <item name="colorTextField">@color/light_gray</item>


### PR DESCRIPTION
Атрибут background применялся к нежелательным системным элементам, например выделение текста. Заменено на windowBackground.
Исправлены цвета на экранах, где явно не был указан background.
Пример с выделением текста:
<img width="287" height="89" alt="изображение" src="https://github.com/user-attachments/assets/87eb27e6-9d04-4019-a1f2-78ee0b988fc6" />