### PR TITLE
Feature #40 fragment viewmodel vacancy

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
@@ -18,14 +18,12 @@ import ru.practicum.android.diploma.util.ConnectionChecker
 
 const val VACANCY_BASE_URL = "https://android-diploma.education-services.ru/"
 
-const val apiAcces = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJwcmFjdGljdW0ucnUiLCJhdWQiOiJwcmFjdGljdW0ucnUiLCJ1c2VybmFtZSI6InBsdXNpa25vaXN5QGdtYWlsLmNvbSJ9.2n5ISGkvja0Xb8Q_FJ--ukXyJ0v_tZolj87leTRr0bg"
-
 val dataModule = module {
 
     single<VacancyApiService> {
         Retrofit.Builder()
             .baseUrl(VACANCY_BASE_URL)
-            .client(OkHttpClient.Builder().addInterceptor(AuthInterceptor(apiAcces)).build())
+            .client(OkHttpClient.Builder().addInterceptor(AuthInterceptor(BuildConfig.API_ACCESS_TOKEN)).build())
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(VacancyApiService::class.java)

--- a/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
@@ -16,12 +16,14 @@ import ru.practicum.android.diploma.util.ConnectionChecker
 
 const val VACANCY_BASE_URL = "https://android-diploma.education-services.ru/"
 
+const val apiAcces = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJwcmFjdGljdW0ucnUiLCJhdWQiOiJwcmFjdGljdW0ucnUiLCJ1c2VybmFtZSI6InBsdXNpa25vaXN5QGdtYWlsLmNvbSJ9.2n5ISGkvja0Xb8Q_FJ--ukXyJ0v_tZolj87leTRr0bg"
+
 val dataModule = module {
 
     single<VacancyApiService> {
         Retrofit.Builder()
             .baseUrl(VACANCY_BASE_URL)
-            .client(OkHttpClient.Builder().addInterceptor(AuthInterceptor(BuildConfig.API_ACCESS_TOKEN)).build())
+            .client(OkHttpClient.Builder().addInterceptor(AuthInterceptor(apiAcces)).build())
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(VacancyApiService::class.java)

--- a/app/src/main/java/ru/practicum/android/diploma/di/ViewModelModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/ViewModelModule.kt
@@ -2,8 +2,8 @@ package ru.practicum.android.diploma.di
 
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
-import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyViewModel
 import ru.practicum.android.diploma.feature.favorite.presentation.FavoriteFragmentViewModel
+import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyViewModel
 
 val viewModelModule = module {
 

--- a/app/src/main/java/ru/practicum/android/diploma/di/ViewModelModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/ViewModelModule.kt
@@ -1,7 +1,11 @@
 package ru.practicum.android.diploma.di
 
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
+import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyViewModel
 
 val viewModelModule = module {
-
+    viewModel {
+        VacancyViewModel(get())
+    }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/data/network/VacancyApiService.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/data/network/VacancyApiService.kt
@@ -4,6 +4,7 @@ import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.QueryMap
 import ru.practicum.android.diploma.feature.search.data.dto.VacancySearchResponse
+import ru.practicum.android.diploma.feature.vacancy.data.dto.VacancyDetailResponse
 
 interface VacancyApiService {
     @GET("vacancies")
@@ -14,5 +15,5 @@ interface VacancyApiService {
     @GET("vacancies/{id}")
     suspend fun getVacancyDetail(
         @Path("id") id: String
-    ): VacancySearchResponse
+    ): VacancyDetailResponse
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchFragment.kt
@@ -5,8 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
-import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentSearchBinding
 
 class SearchFragment : Fragment() {
@@ -32,9 +30,12 @@ class SearchFragment : Fragment() {
             findNavController().navigate(R.id.action_searchFragment_to_vacancyFragment)
         }*/
 
-        binding.placeholderImage.setOnClickListener {
-            findNavController().navigate(R.id.action_searchFragment_to_vacancyFragment)
-        }
+        /*
+        передача аргумента в фрагмент
+        val action = SearchFragmentDirections.actionSearchFragmentToVacancyFragment(vacancyId = "12345")
+        findNavController().navigate(action)
+        */
+
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchFragment.kt
@@ -35,7 +35,6 @@ class SearchFragment : Fragment() {
         val action = SearchFragmentDirections.actionSearchFragmentToVacancyFragment(vacancyId = "12345")
         findNavController().navigate(action)
         */
-
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchFragment.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentSearchBinding
 
 class SearchFragment : Fragment() {
@@ -29,6 +31,10 @@ class SearchFragment : Fragment() {
         binding.navigateToVacancyButton.setOnClickListener {
             findNavController().navigate(R.id.action_searchFragment_to_vacancyFragment)
         }*/
+
+        binding.placeholderImage.setOnClickListener {
+            findNavController().navigate(R.id.action_searchFragment_to_vacancyFragment)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/data/impl/VacancyRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/data/impl/VacancyRepositoryImpl.kt
@@ -22,8 +22,9 @@ class VacancyRepositoryImpl(
                 val data = response as VacancyDetailResponse
                 emit(Resource.Success(vacancyDetailMapper.map(data)))
             }
-
             NO_INTERNET_CODE -> emit(Resource.Error("Нет интернета"))
+            PAGE_NOT_FOUND -> emit(Resource.Error("Вакансия не найдена или\nудалена"))
+
             else -> emit(Resource.Error("Ошибка сервера"))
         }
     }
@@ -43,5 +44,7 @@ class VacancyRepositoryImpl(
     companion object {
         private const val NO_INTERNET_CODE = -1
         private const val SUCCESS_CODE = 200
+
+        private const val PAGE_NOT_FOUND = 400
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/data/impl/VacancyRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/data/impl/VacancyRepositoryImpl.kt
@@ -23,7 +23,7 @@ class VacancyRepositoryImpl(
                 emit(Resource.Success(vacancyDetailMapper.map(data)))
             }
 
-            NO_INTERNET_CODE -> emit(Resource.Error("Проверьте подключение к интернету"))
+            NO_INTERNET_CODE -> emit(Resource.Error("Нет интернета"))
             else -> emit(Resource.Error("Ошибка сервера"))
         }
     }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/data/navigator/ExternalNavigatorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/data/navigator/ExternalNavigatorImpl.kt
@@ -27,7 +27,10 @@ class ExternalNavigatorImpl(private val context: Context) : ExternalNavigator {
             putExtra(Intent.EXTRA_EMAIL, arrayOf(email))
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        context.startActivity(intent)
+        val chooser = Intent.createChooser(intent, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(chooser)
     }
 
     override fun makeCall(phoneNumber: String) {
@@ -35,6 +38,9 @@ class ExternalNavigatorImpl(private val context: Context) : ExternalNavigator {
             data = Uri.parse("tel:$phoneNumber")
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        context.startActivity(intent)
+        val chooser = Intent.createChooser(intent, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(chooser)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyState.kt
@@ -1,13 +1,9 @@
 package ru.practicum.android.diploma.feature.vacancy.presentation
 
-import androidx.annotation.StringRes
 import ru.practicum.android.diploma.feature.vacancy.domain.model.VacancyDetail
 
 sealed class VacancyState {
     object Loading : VacancyState()
     data class Content(val content: VacancyDetail) : VacancyState()
     data class Error(val errorMessage: String) : VacancyState()
-
-    data class Empty(@StringRes val message: Int) : VacancyState()
-
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyState.kt
@@ -3,9 +3,11 @@ package ru.practicum.android.diploma.feature.vacancy.presentation
 import androidx.annotation.StringRes
 import ru.practicum.android.diploma.feature.vacancy.domain.model.VacancyDetail
 
-sealed class VacancyState{
+sealed class VacancyState {
     object Loading : VacancyState()
     data class Content(val content: VacancyDetail) : VacancyState()
     data class Error(val errorMessage: String) : VacancyState()
+
+    data class Empty(@StringRes val message: Int) : VacancyState()
 
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyState.kt
@@ -1,9 +1,11 @@
 package ru.practicum.android.diploma.feature.vacancy.presentation
 
+import androidx.annotation.StringRes
 import ru.practicum.android.diploma.feature.vacancy.domain.model.VacancyDetail
 
 sealed class VacancyState{
     object Loading : VacancyState()
     data class Content(val content: VacancyDetail) : VacancyState()
     data class Error(val errorMessage: String) : VacancyState()
+
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyState.kt
@@ -1,0 +1,9 @@
+package ru.practicum.android.diploma.feature.vacancy.presentation
+
+import ru.practicum.android.diploma.feature.vacancy.domain.model.VacancyDetail
+
+sealed class VacancyState{
+    object Loading : VacancyState()
+    data class Content(val content: VacancyDetail) : VacancyState()
+    data class Error(val errorMessage: String) : VacancyState()
+}

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
+import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.feature.vacancy.domain.api.VacancyInteractor
 import ru.practicum.android.diploma.util.Resource
 
@@ -20,29 +21,32 @@ class VacancyViewModel(private val vacancyInteractor: VacancyInteractor) : ViewM
                 when (it) {
                     is Resource.Error -> _vacancyDetail.postValue(VacancyState.Error(it.message!!))
                     is Resource.Success -> {
-                        if (it.data)
-                        _vacancyDetail.postValue(VacancyState.Content(it.data!!))
+                        if (it.data != null) {
+                            _vacancyDetail.postValue(VacancyState.Content(it.data))
+                        } else {
+                            _vacancyDetail.postValue(VacancyState.Empty(R.string.vacancy_not_found))
+                        }
                     }
                 }
             }
         }
     }
 
-    fun sendVacancyViaMessenger(url: String){
+    fun sendVacancyViaMessenger(url: String) {
         viewModelScope.launch {
             vacancyInteractor.sendVacancyViaMessenger(url)
         }
     }
-    fun selectEmailClientAndSend(email: String){
+
+    fun selectEmailClientAndSend(email: String) {
         viewModelScope.launch {
             vacancyInteractor.selectEmailClientAndSend(email)
         }
     }
-    fun showCallAppsAndDial(phoneNumber: String){
+
+    fun showCallAppsAndDial(phoneNumber: String) {
         viewModelScope.launch {
             vacancyInteractor.showCallAppsAndDial(phoneNumber)
         }
     }
-
-
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.feature.vacancy.domain.api.VacancyInteractor
 import ru.practicum.android.diploma.util.Resource
 
@@ -20,13 +19,7 @@ class VacancyViewModel(private val vacancyInteractor: VacancyInteractor) : ViewM
             vacancyInteractor.getVacancyDetail(id).collect {
                 when (it) {
                     is Resource.Error -> _vacancyDetail.postValue(VacancyState.Error(it.message!!))
-                    is Resource.Success -> {
-                        if (it.data != null) {
-                            _vacancyDetail.postValue(VacancyState.Content(it.data))
-                        } else {
-                            _vacancyDetail.postValue(VacancyState.Empty(R.string.vacancy_not_found))
-                        }
-                    }
+                    is Resource.Success -> _vacancyDetail.postValue(VacancyState.Content(it.data!!))
                 }
             }
         }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyViewModel.kt
@@ -1,0 +1,45 @@
+package ru.practicum.android.diploma.feature.vacancy.presentation
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import ru.practicum.android.diploma.feature.vacancy.domain.api.VacancyInteractor
+import ru.practicum.android.diploma.util.Resource
+
+class VacancyViewModel(private val vacancyInteractor: VacancyInteractor) : ViewModel() {
+
+    private val _vacancyDetail = MutableLiveData<VacancyState>()
+    fun observeVacancyDetail(): LiveData<VacancyState> = _vacancyDetail
+
+    fun getVacancyDetail(id: String) {
+        viewModelScope.launch {
+            _vacancyDetail.postValue(VacancyState.Loading)
+            vacancyInteractor.getVacancyDetail(id).collect {
+                when (it) {
+                    is Resource.Error -> _vacancyDetail.postValue(VacancyState.Error(it.message!!))
+                    is Resource.Success -> _vacancyDetail.postValue(VacancyState.Content(it.data!!))
+                }
+            }
+        }
+    }
+
+    fun sendVacancyViaMessenger(url: String){
+        viewModelScope.launch {
+            vacancyInteractor.sendVacancyViaMessenger(url)
+        }
+    }
+    fun selectEmailClientAndSend(email: String){
+        viewModelScope.launch {
+            vacancyInteractor.selectEmailClientAndSend(email)
+        }
+    }
+    fun showCallAppsAndDial(phoneNumber: String){
+        viewModelScope.launch {
+            vacancyInteractor.showCallAppsAndDial(phoneNumber)
+        }
+    }
+
+
+}

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/presentation/VacancyViewModel.kt
@@ -19,7 +19,10 @@ class VacancyViewModel(private val vacancyInteractor: VacancyInteractor) : ViewM
             vacancyInteractor.getVacancyDetail(id).collect {
                 when (it) {
                     is Resource.Error -> _vacancyDetail.postValue(VacancyState.Error(it.message!!))
-                    is Resource.Success -> _vacancyDetail.postValue(VacancyState.Content(it.data!!))
+                    is Resource.Success -> {
+                        if (it.data)
+                        _vacancyDetail.postValue(VacancyState.Content(it.data!!))
+                    }
                 }
             }
         }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/ContactsFormatter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/ContactsFormatter.kt
@@ -1,0 +1,124 @@
+package ru.practicum.android.diploma.feature.vacancy.ui
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import android.view.View
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.google.android.material.textview.MaterialTextView
+import ru.practicum.android.diploma.R
+import ru.practicum.android.diploma.databinding.FragmentVacancyBinding
+import ru.practicum.android.diploma.feature.vacancy.domain.model.Contacts
+import ru.practicum.android.diploma.feature.vacancy.domain.model.VacancyDetail
+import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyViewModel
+import ru.practicum.android.diploma.feature.vacancy.ui.model.PhoneInfo
+import ru.practicum.android.diploma.util.fromDpToPx
+
+class ContactsFormatter(
+    private val binding: FragmentVacancyBinding,
+    private val vacancyViewModel: VacancyViewModel,
+    private val context: Context
+) {
+
+    fun setupContacts(vacancy: VacancyDetail) {
+        val contacts = vacancy.contacts
+        val isContactsEmpty = contacts == null ||
+            contacts.name.isNullOrEmpty() &&
+            contacts.email.isNullOrEmpty() &&
+            contacts.phones?.isEmpty() == true
+
+        if (isContactsEmpty) {
+            binding.contactGroup.visibility = View.GONE
+        } else {
+            binding.contactGroup.visibility = View.VISIBLE
+            displayContactData(contacts)
+        }
+    }
+
+    private fun displayContactData(contacts: Contacts?) {
+        if (contacts == null) return
+
+        setupContactName(contacts.name)
+        setupContactEmail(contacts.email)
+
+        if (!contacts.phones.isNullOrEmpty()) {
+            val phoneInfos = contacts.phones.map {
+                PhoneInfo(it.comment, it.formatted ?: "")
+            }
+            onPhoneInfoReceived(phoneInfos)
+        }
+    }
+
+    private fun setupContactName(name: String?) {
+        binding.vacancyContactName.apply {
+            text = name
+            visibility = if (name.isNullOrEmpty()) View.GONE else View.VISIBLE
+        }
+    }
+
+    private fun setupContactEmail(email: String?) {
+        binding.vacancyContactEmail.apply {
+            text = email
+            visibility = if (email.isNullOrEmpty()) View.GONE else View.VISIBLE
+            setOnClickListener {
+                email?.let { vacancyViewModel.selectEmailClientAndSend(it) }
+            }
+        }
+    }
+
+    private fun onPhoneInfoReceived(phones: List<PhoneInfo>) {
+        if (phones.isNotEmpty()) {
+            var upperId = binding.vacancyContactEmail.id
+            for (phone in phones) {
+                if (phone.comment != null) {
+                    upperId = initPhoneView(
+                        MaterialTextView(getPhoneCommentContextThemeWrapper()),
+                        upperId,
+                        phone.comment
+                    )
+                }
+                val phoneTextView = MaterialTextView(getPhoneContextThemeWrapper())
+                phoneTextView.setOnClickListener { vacancyViewModel.showCallAppsAndDial(phone.phone) }
+                upperId = initPhoneView(phoneTextView, upperId, phone.phone)
+            }
+        }
+    }
+
+    private fun initPhoneView(view: TextView, upperId: Int, text: String): Int {
+        val generatedId = View.generateViewId()
+        view.apply {
+            id = generatedId
+            this.text = text
+            layoutParams = getPhoneLayoutParams(upperId)
+        }
+        binding.vacancyLayout.addView(view)
+        return generatedId
+    }
+
+    private fun getPhoneLayoutParams(upperId: Int): ConstraintLayout.LayoutParams =
+        ConstraintLayout.LayoutParams(
+            ConstraintLayout.LayoutParams.WRAP_CONTENT,
+            ConstraintLayout.LayoutParams.WRAP_CONTENT
+        ).apply {
+            topToBottom = upperId
+            topMargin = PHONE_VIEW_TOP_MARGIN.fromDpToPx(context)
+            startToEnd = binding.start16Line.id
+            endToStart = binding.end16Line.id
+            horizontalBias = HORIZONTAL_BIAS
+        }
+
+    private fun getPhoneContextThemeWrapper() = ContextThemeWrapper(
+        context,
+        R.style.VacancyContactHighlightTextViewStyle
+    )
+
+    private fun getPhoneCommentContextThemeWrapper() = ContextThemeWrapper(
+        context,
+        R.style.VacancyDetailsSingleTextViewStyle
+    )
+
+    companion object {
+        private const val PHONE_VIEW_TOP_MARGIN = 8
+        private const val HORIZONTAL_BIAS = 0f
+    }
+}

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
@@ -1,9 +1,6 @@
 package ru.practicum.android.diploma.feature.vacancy.ui
 
 import android.os.Bundle
-import android.telephony.PhoneNumberUtils
-import android.text.Html
-import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
@@ -11,16 +8,20 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
 import com.google.android.material.textview.MaterialTextView
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentVacancyBinding
+import ru.practicum.android.diploma.feature.vacancy.domain.model.Contacts
 import ru.practicum.android.diploma.feature.vacancy.domain.model.VacancyDetail
 import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyState
 import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyViewModel
 import ru.practicum.android.diploma.feature.vacancy.ui.model.PhoneInfo
 import ru.practicum.android.diploma.util.fromDpToPx
+import ru.practicum.android.diploma.util.ui.DescriptionFormatterVacancy
+import ru.practicum.android.diploma.util.ui.SalaryFormatterVacancy
 
 class VacancyFragment : Fragment() {
 
@@ -29,9 +30,9 @@ class VacancyFragment : Fragment() {
     private var _binding: FragmentVacancyBinding? = null
     private val binding get() = _binding!!
 
-    private lateinit var contentVacancy: VacancyDetail
+    private var contentVacancy: VacancyDetail? = null
 
-
+    private val args by navArgs<VacancyFragmentArgs>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -49,16 +50,17 @@ class VacancyFragment : Fragment() {
             requireActivity().supportFragmentManager.popBackStack()
         }
 
-        val idTest = "00072a6b-b4a0-4547-9913-3ffa27cdbf32"
-        vacancyViewModel.getVacancyDetail(idTest)
+        // можно потестить захардкодить разные id
+        val id = args.vacancyId
+        vacancyViewModel.getVacancyDetail(id)
         vacancyViewModel.observeVacancyDetail().observe(viewLifecycleOwner) {
             render(it)
-            Log.d("VacancyFragment", "onViewCreated: $it")
         }
 
         binding.share.setOnClickListener {
-            vacancyViewModel.sendVacancyViaMessenger(contentVacancy.url!!)
-
+            contentVacancy?.url?.let { url ->
+                vacancyViewModel.sendVacancyViaMessenger(url)
+            }
         }
     }
 
@@ -72,13 +74,26 @@ class VacancyFragment : Fragment() {
             is VacancyState.Content -> showContent(state)
             is VacancyState.Error -> showError(state)
             is VacancyState.Loading -> showLoading()
+            is VacancyState.Empty -> showEmpty(state)
+        }
+    }
+
+    private fun showEmpty(content: VacancyState.Empty) {
+        with(binding) {
+            progressBar.visibility = View.GONE
+            vacancyLayout.visibility = View.GONE
+            share.visibility = View.GONE
+            addToFavorites.visibility = View.GONE
+            placeHolderForEmpty.visibility = View.VISIBLE
+            emptyTv.setText(content.message)
         }
     }
 
     private fun showContent(content: VacancyState.Content) {
         val vacancy = content.content
-        contentVacancy = content.content
+        contentVacancy = vacancy
         with(binding) {
+            placeHolderForEmpty.visibility = View.INVISIBLE
             share.visibility = View.VISIBLE
             addToFavorites.visibility = View.VISIBLE
             progressBar.visibility = View.GONE
@@ -86,8 +101,16 @@ class VacancyFragment : Fragment() {
             serverError.visibility = View.GONE
             noInternetPlaceHolder.visibility = View.GONE
 
+            setupMainInfo(vacancy)
+            setupSkills(vacancy.skills)
+            setupContacts(vacancy)
+        }
+    }
+
+    private fun setupMainInfo(vacancy: VacancyDetail) {
+        with(binding) {
             vacancyName.text = vacancy.name
-            vacancySalary.text = formatSalary(vacancy.salary!!)
+            vacancySalary.text = SalaryFormatterVacancy(vacancy.salary, requireContext()).format()
 
             employerName.text = vacancy.employer?.name
             regionCity.text = vacancy.address?.city ?: vacancy.area?.name
@@ -100,138 +123,107 @@ class VacancyFragment : Fragment() {
             requiredExperience.text = vacancy.experience?.name
             val scheduleText = "${vacancy.employment?.name}, ${vacancy.schedule?.name}"
             employmentSchedule.text = scheduleText
-
-            val rawDescription = vacancy.description
-            binding.vacancyDescription.text = rawDescription
-
-
-            if (vacancy.skills.isNullOrEmpty()) {
-                skillsGroup.visibility = View.GONE
-            } else {
-                skillsGroup.visibility = View.VISIBLE
-                vacancySkills.text = vacancy.skills.joinToString("\n") { " • $it" }
-            }
-
-            val contacts = vacancy.contacts
-            if (contacts == null || (contacts.name.isNullOrEmpty() && contacts.email.isNullOrEmpty() && contacts.phones!!.isEmpty())) {
-                contactGroup.visibility = View.GONE
-            } else {
-                contactGroup.visibility = View.VISIBLE
-
-                if (!contacts.name.isNullOrEmpty()) {
-                    vacancyContactName.text = contacts.name
-                    vacancyContactName.visibility = View.VISIBLE
-                } else {
-                    vacancyContactName.visibility = View.GONE
-                }
-
-                if (!contacts.email.isNullOrEmpty()) {
-                    vacancyContactEmail.text = contacts.email
-                    vacancyContactEmail.visibility = View.VISIBLE
-                    vacancyContactEmail.setOnClickListener {
-                        vacancyViewModel.selectEmailClientAndSend(contacts.email)
-                    }
-                } else {
-                    vacancyContactEmail.visibility = View.GONE
-                }
-
-                if (contacts.phones!!.isNotEmpty()) {
-                    val phoneInfos = contacts.phones.map {
-                        PhoneInfo(it.comment, it.formatted!!)
-                    }
-                    onPhoneInfoReceived(phoneInfos)
-                }
-            }
+            // нужна функция форматирования текста?
+            vacancyDescription.text = DescriptionFormatterVacancy(vacancy.description).format()
         }
     }
 
-    private fun formatSalary(salary: ru.practicum.android.diploma.feature.vacancy.domain.model.Salary): String {
-        if (salary == null || (salary.from == null && salary.to == null)) {
-            return getString(R.string.salary_not_specified)
+    private fun setupSkills(skills: List<String>?) {
+        if (skills.isNullOrEmpty()) {
+            binding.skillsGroup.visibility = View.GONE
+        } else {
+            binding.skillsGroup.visibility = View.VISIBLE
+            binding.vacancySkills.text = skills.joinToString("\n") { " • $it" }
         }
-
-        val text = StringBuilder()
-
-        // Используем ваш метод formatNumber для разделения разрядов пробелами
-        salary.from?.let {
-            text.append("от ${formatNumber(it)} ")
-        }
-        salary.to?.let {
-            text.append("до ${formatNumber(it)} ")
-        }
-
-        val currencySymbol = when (salary.currency) {
-            "AZN" -> "₼"
-            "BYR" -> "Br"
-            "EUR" -> "€"
-            "GEL" -> "₾"
-            "KGS" -> "с"
-            "KZT" -> "₸"
-            "RUR" -> "₽"
-            "UAH" -> "₴"
-            "USD" -> "$"
-            "UZS" -> "so'm"
-            else -> salary.currency
-        }
-        text.append(currencySymbol)
-
-        return text.toString()
     }
 
-    private fun formatNumber(number: Int): String {
-        return java.text.DecimalFormat("#,###").format(number).replace(",", " ")
+    private fun setupContacts(vacancy: VacancyDetail) {
+        val contacts = vacancy.contacts
+        val isContactsEmpty = contacts == null ||
+            contacts.name.isNullOrEmpty() &&
+            contacts.email.isNullOrEmpty() &&
+            contacts.phones?.isEmpty() == true
+
+        if (isContactsEmpty) {
+            binding.contactGroup.visibility = View.GONE
+        } else {
+            binding.contactGroup.visibility = View.VISIBLE
+            displayContactData(contacts)
+        }
+    }
+
+    private fun displayContactData(contacts: Contacts?) {
+        if (contacts == null) return
+
+        setupContactName(contacts.name)
+        setupContactEmail(contacts.email)
+
+        if (!contacts.phones.isNullOrEmpty()) {
+            val phoneInfos = contacts.phones.map {
+                PhoneInfo(it.comment, it.formatted ?: "")
+            }
+            onPhoneInfoReceived(phoneInfos)
+        }
+    }
+
+    private fun setupContactName(name: String?) {
+        binding.vacancyContactName.apply {
+            text = name
+            visibility = if (name.isNullOrEmpty()) View.GONE else View.VISIBLE
+        }
+    }
+
+    private fun setupContactEmail(email: String?) {
+        binding.vacancyContactEmail.apply {
+            text = email
+            visibility = if (email.isNullOrEmpty()) View.GONE else View.VISIBLE
+            setOnClickListener {
+                email?.let { vacancyViewModel.selectEmailClientAndSend(it) }
+            }
+        }
     }
 
     private fun showError(error: VacancyState.Error) {
-        binding.progressBar.visibility = View.GONE
-        if (error.errorMessage == getString(R.string.no_internet)) {
-            binding.share.visibility = View.GONE
-            binding.addToFavorites.visibility = View.GONE
-            binding.noInternetPlaceHolder.visibility = View.VISIBLE
-            binding.serverError.visibility = View.GONE
-            binding.vacancyLayout.visibility = View.GONE
-        }else{
-            binding.share.visibility = View.GONE
-            binding.addToFavorites.visibility = View.GONE
-            binding.noInternetPlaceHolder.visibility = View.GONE
-            binding.serverError.visibility = View.VISIBLE
-            binding.vacancyLayout.visibility = View.GONE
+        val isNoInternet = error.errorMessage == getString(R.string.no_internet)
+        with(binding) {
+            placeHolderForEmpty.visibility = View.INVISIBLE
+            progressBar.visibility = View.GONE
+            share.visibility = View.GONE
+            addToFavorites.visibility = View.GONE
+            vacancyLayout.visibility = View.GONE
+            noInternetPlaceHolder.visibility = if (isNoInternet) View.VISIBLE else View.GONE
+            serverError.visibility = if (isNoInternet) View.GONE else View.VISIBLE
         }
     }
 
     private fun showLoading() {
-        binding.progressBar.visibility = View.VISIBLE
-        binding.vacancyLayout.visibility = View.GONE
+        with(binding) {
+            placeHolderForEmpty.visibility = View.INVISIBLE
+            progressBar.visibility = View.VISIBLE
+            vacancyLayout.visibility = View.GONE
+            share.visibility = View.GONE
+            addToFavorites.visibility = View.GONE
+        }
     }
 
-    /**
-     * @param phones список телефонов с номерами и возможными комментариями
-     * upperId - id верхнего View, после которого будет добавлен новый View
-     * */
     private fun onPhoneInfoReceived(phones: List<PhoneInfo>) {
         if (phones.isNotEmpty()) {
             var upperId = binding.vacancyContactEmail.id
             for (phone in phones) {
                 if (phone.comment != null) {
                     upperId = initPhoneView(
-                        MaterialTextView(getPhoneCommentContextThemeWrapper()), upperId, phone.comment
+                        MaterialTextView(getPhoneCommentContextThemeWrapper()),
+                        upperId,
+                        phone.comment
                     )
                 }
                 val phoneTextView = MaterialTextView(getPhoneContextThemeWrapper())
                 phoneTextView.setOnClickListener { vacancyViewModel.showCallAppsAndDial(phone.phone) }
-                upperId = initPhoneView(
-                    phoneTextView, upperId, phone.phone
-                )
+                upperId = initPhoneView(phoneTextView, upperId, phone.phone)
             }
         }
     }
 
-    /**
-     * @param view View принимающая текст. Либо комментарий, либо номер телефона
-     * @param upperId текущий upperId
-     * @param text текст на View
-     * @return сгенерированный id для View
-     */
     private fun initPhoneView(view: TextView, upperId: Int, text: String): Int {
         val generatedId = View.generateViewId()
         view.apply {
@@ -243,29 +235,27 @@ class VacancyFragment : Fragment() {
         return generatedId
     }
 
-    /**
-     * @param upperId текущий upperId
-     * @return сгенерированный LayoutParams для View
-     * Новая View будет добавлена под View с upperId
-     */
-    private fun getPhoneLayoutParams(upperId: Int): ConstraintLayout.LayoutParams = ConstraintLayout.LayoutParams(
-        ConstraintLayout.LayoutParams.WRAP_CONTENT,
-        ConstraintLayout.LayoutParams.WRAP_CONTENT
-    ).apply {
-        topToBottom = upperId
-        topMargin = PHONE_VIEW_TOP_MARGIN.fromDpToPx(requireActivity())
-        startToEnd = binding.start16Line.id
-        endToStart = binding.end16Line.id
-        horizontalBias = HORIZONTAL_BIAS
-    }
+    private fun getPhoneLayoutParams(upperId: Int): ConstraintLayout.LayoutParams =
+        ConstraintLayout.LayoutParams(
+            ConstraintLayout.LayoutParams.WRAP_CONTENT,
+            ConstraintLayout.LayoutParams.WRAP_CONTENT
+        ).apply {
+            topToBottom = upperId
+            topMargin = PHONE_VIEW_TOP_MARGIN.fromDpToPx(requireActivity())
+            startToEnd = binding.start16Line.id
+            endToStart = binding.end16Line.id
+            horizontalBias = HORIZONTAL_BIAS
+        }
 
     private fun getPhoneContextThemeWrapper() = ContextThemeWrapper(
         requireContext(),
         R.style.VacancyContactHighlightTextViewStyle
     )
 
-    private fun getPhoneCommentContextThemeWrapper() =
-        ContextThemeWrapper(requireContext(), R.style.VacancyDetailsSingleTextViewStyle)
+    private fun getPhoneCommentContextThemeWrapper() = ContextThemeWrapper(
+        requireContext(),
+        R.style.VacancyDetailsSingleTextViewStyle
+    )
 
     companion object {
         private const val PHONE_VIEW_TOP_MARGIN = 8

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
@@ -1,25 +1,18 @@
 package ru.practicum.android.diploma.feature.vacancy.ui
 
 import android.os.Bundle
-import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
-import com.google.android.material.textview.MaterialTextView
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentVacancyBinding
-import ru.practicum.android.diploma.feature.vacancy.domain.model.Contacts
 import ru.practicum.android.diploma.feature.vacancy.domain.model.VacancyDetail
 import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyState
 import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyViewModel
-import ru.practicum.android.diploma.feature.vacancy.ui.model.PhoneInfo
-import ru.practicum.android.diploma.util.fromDpToPx
 import ru.practicum.android.diploma.util.ui.DescriptionFormatterVacancy
 import ru.practicum.android.diploma.util.ui.SalaryFormatterVacancy
 
@@ -74,18 +67,6 @@ class VacancyFragment : Fragment() {
             is VacancyState.Content -> showContent(state)
             is VacancyState.Error -> showError(state)
             is VacancyState.Loading -> showLoading()
-            is VacancyState.Empty -> showEmpty(state)
-        }
-    }
-
-    private fun showEmpty(content: VacancyState.Empty) {
-        with(binding) {
-            progressBar.visibility = View.GONE
-            vacancyLayout.visibility = View.GONE
-            share.visibility = View.GONE
-            addToFavorites.visibility = View.GONE
-            placeHolderForEmpty.visibility = View.VISIBLE
-            emptyTv.setText(content.message)
         }
     }
 
@@ -93,7 +74,7 @@ class VacancyFragment : Fragment() {
         val vacancy = content.content
         contentVacancy = vacancy
         with(binding) {
-            placeHolderForEmpty.visibility = View.INVISIBLE
+            placeHolderForEmpty.visibility = View.GONE
             share.visibility = View.VISIBLE
             addToFavorites.visibility = View.VISIBLE
             progressBar.visibility = View.GONE
@@ -103,7 +84,7 @@ class VacancyFragment : Fragment() {
 
             setupMainInfo(vacancy)
             setupSkills(vacancy.skills)
-            setupContacts(vacancy)
+            ContactsFormatter(binding, vacancyViewModel, requireContext()).setupContacts(vacancy)
         }
     }
 
@@ -137,128 +118,42 @@ class VacancyFragment : Fragment() {
         }
     }
 
-    private fun setupContacts(vacancy: VacancyDetail) {
-        val contacts = vacancy.contacts
-        val isContactsEmpty = contacts == null ||
-            contacts.name.isNullOrEmpty() &&
-            contacts.email.isNullOrEmpty() &&
-            contacts.phones?.isEmpty() == true
-
-        if (isContactsEmpty) {
-            binding.contactGroup.visibility = View.GONE
-        } else {
-            binding.contactGroup.visibility = View.VISIBLE
-            displayContactData(contacts)
-        }
-    }
-
-    private fun displayContactData(contacts: Contacts?) {
-        if (contacts == null) return
-
-        setupContactName(contacts.name)
-        setupContactEmail(contacts.email)
-
-        if (!contacts.phones.isNullOrEmpty()) {
-            val phoneInfos = contacts.phones.map {
-                PhoneInfo(it.comment, it.formatted ?: "")
-            }
-            onPhoneInfoReceived(phoneInfos)
-        }
-    }
-
-    private fun setupContactName(name: String?) {
-        binding.vacancyContactName.apply {
-            text = name
-            visibility = if (name.isNullOrEmpty()) View.GONE else View.VISIBLE
-        }
-    }
-
-    private fun setupContactEmail(email: String?) {
-        binding.vacancyContactEmail.apply {
-            text = email
-            visibility = if (email.isNullOrEmpty()) View.GONE else View.VISIBLE
-            setOnClickListener {
-                email?.let { vacancyViewModel.selectEmailClientAndSend(it) }
-            }
-        }
-    }
-
     private fun showError(error: VacancyState.Error) {
-        val isNoInternet = error.errorMessage == getString(R.string.no_internet)
         with(binding) {
-            placeHolderForEmpty.visibility = View.INVISIBLE
             progressBar.visibility = View.GONE
+            vacancyLayout.visibility = View.GONE
             share.visibility = View.GONE
             addToFavorites.visibility = View.GONE
-            vacancyLayout.visibility = View.GONE
-            noInternetPlaceHolder.visibility = if (isNoInternet) View.VISIBLE else View.GONE
-            serverError.visibility = if (isNoInternet) View.GONE else View.VISIBLE
+
+            noInternetPlaceHolder.visibility = View.GONE
+            serverError.visibility = View.GONE
+            placeHolderForEmpty.visibility = View.GONE
+
+            when (error.errorMessage) {
+                getString(R.string.no_internet) -> {
+                    noInternetPlaceHolder.visibility = View.VISIBLE
+                }
+
+                getString(R.string.vacancy_not_found) -> {
+                    placeHolderForEmpty.visibility = View.VISIBLE
+                }
+
+                else -> {
+                    serverError.visibility = View.VISIBLE
+                }
+            }
         }
     }
 
     private fun showLoading() {
         with(binding) {
-            placeHolderForEmpty.visibility = View.INVISIBLE
+            placeHolderForEmpty.visibility = View.GONE
+            serverError.visibility = View.GONE
+            noInternetPlaceHolder.visibility = View.GONE
             progressBar.visibility = View.VISIBLE
             vacancyLayout.visibility = View.GONE
             share.visibility = View.GONE
             addToFavorites.visibility = View.GONE
         }
-    }
-
-    private fun onPhoneInfoReceived(phones: List<PhoneInfo>) {
-        if (phones.isNotEmpty()) {
-            var upperId = binding.vacancyContactEmail.id
-            for (phone in phones) {
-                if (phone.comment != null) {
-                    upperId = initPhoneView(
-                        MaterialTextView(getPhoneCommentContextThemeWrapper()),
-                        upperId,
-                        phone.comment
-                    )
-                }
-                val phoneTextView = MaterialTextView(getPhoneContextThemeWrapper())
-                phoneTextView.setOnClickListener { vacancyViewModel.showCallAppsAndDial(phone.phone) }
-                upperId = initPhoneView(phoneTextView, upperId, phone.phone)
-            }
-        }
-    }
-
-    private fun initPhoneView(view: TextView, upperId: Int, text: String): Int {
-        val generatedId = View.generateViewId()
-        view.apply {
-            id = generatedId
-            this.text = text
-            layoutParams = getPhoneLayoutParams(upperId)
-        }
-        binding.vacancyLayout.addView(view)
-        return generatedId
-    }
-
-    private fun getPhoneLayoutParams(upperId: Int): ConstraintLayout.LayoutParams =
-        ConstraintLayout.LayoutParams(
-            ConstraintLayout.LayoutParams.WRAP_CONTENT,
-            ConstraintLayout.LayoutParams.WRAP_CONTENT
-        ).apply {
-            topToBottom = upperId
-            topMargin = PHONE_VIEW_TOP_MARGIN.fromDpToPx(requireActivity())
-            startToEnd = binding.start16Line.id
-            endToStart = binding.end16Line.id
-            horizontalBias = HORIZONTAL_BIAS
-        }
-
-    private fun getPhoneContextThemeWrapper() = ContextThemeWrapper(
-        requireContext(),
-        R.style.VacancyContactHighlightTextViewStyle
-    )
-
-    private fun getPhoneCommentContextThemeWrapper() = ContextThemeWrapper(
-        requireContext(),
-        R.style.VacancyDetailsSingleTextViewStyle
-    )
-
-    companion object {
-        private const val PHONE_VIEW_TOP_MARGIN = 8
-        private const val HORIZONTAL_BIAS = 0f
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
@@ -49,7 +49,7 @@ class VacancyFragment : Fragment() {
             requireActivity().supportFragmentManager.popBackStack()
         }
 
-        val idTest = "026e3822-7106-4332-a39e-35e6dadd6936"
+        val idTest = "00072a6b-b4a0-4547-9913-3ffa27cdbf32"
         vacancyViewModel.getVacancyDetail(idTest)
         vacancyViewModel.observeVacancyDetail().observe(viewLifecycleOwner) {
             render(it)
@@ -114,47 +114,7 @@ class VacancyFragment : Fragment() {
 
             val rawDescription = vacancy.description
 
-            val formattedHtml = rawDescription?.let { raw ->
-                val blocks = raw.split("\n\n")
-                val result = StringBuilder()
-
-                blocks.forEachIndexed { index, block ->
-                    val lines = block.split("\n").map { it.trim() }.filter { it.isNotBlank() }
-                    if (lines.isEmpty()) return@forEachIndexed
-
-                    val firstLine = lines[0]
-                    // Универсальный заголовок: оканчивается на ":" или короткая строка
-                    val isHeader = firstLine.endsWith(":")
-
-                    // Добавляем лишний перенос перед заголовком, если это не самый первый блок
-                    if (isHeader && index > 0) {
-                        result.append("<br><br>")
-                    } else if (index > 0) {
-                        result.append("<br>")
-                    }
-
-                    if (isHeader) {
-                        result.append("<strong>$firstLine</strong>")
-                        if (lines.size > 1) {
-                            val listItems = lines.drop(1).joinToString("<br>") { line ->
-                                "&nbsp;&nbsp;•&nbsp;${line.removePrefix("-").removePrefix("•").trim()}"
-                            }
-                            result.append("<br>$listItems")
-                        }
-                    } else {
-                        if (lines.size > 1) {
-                            result.append(lines.joinToString("<br>") { line ->
-                                "&nbsp;&nbsp;•&nbsp;${line.removePrefix("-").removePrefix("•").trim()}"
-                            })
-                        } else {
-                            result.append(firstLine)
-                        }
-                    }
-                }
-                result.toString()
-            }
-
-            binding.vacancyDescription.text = Html.fromHtml(formattedHtml, Html.FROM_HTML_MODE_LEGACY)
+            binding.vacancyDescription.text = formatRawDescription(rawDescription)
 
 
             // 6. Ключевые навыки (используем skillsGroup для управления видимостью)
@@ -201,6 +161,76 @@ class VacancyFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun formatRawDescription(rawText: String?): CharSequence {
+        if (rawText.isNullOrBlank()) return ""
+
+        val spannableBuilder = android.text.SpannableStringBuilder()
+
+        // Разделяем на строки и очищаем от лишних пробелов
+        val lines = rawText.split("\n")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        lines.forEach { line ->
+            // Очищаем строку от стандартных маркеров списков
+            val cleanLine = line.removePrefix("-").removePrefix("•").removePrefix("*").trim()
+
+            // Критерии заголовка (короткая строка, двоеточие в конце или отсутствие знаков препинания)
+            val isHeader = line.endsWith(":") || (
+                line.length < 30 &&
+                    !line.endsWith(".") &&
+                    !line.endsWith(";") &&
+                    !line.contains(",")
+                )
+
+            if (isHeader) {
+                // Убираем двоеточие в конце заголовка, если оно есть
+                val headerTitle = cleanLine.removeSuffix(":")
+
+                if (spannableBuilder.isNotEmpty()) {
+                    spannableBuilder.append("\n\n")
+                }
+                val start = spannableBuilder.length
+                spannableBuilder.append(headerTitle)
+                val end = spannableBuilder.length
+
+                // Жирный шрифт для заголовка
+                spannableBuilder.setSpan(
+                    android.text.style.StyleSpan(android.graphics.Typeface.BOLD),
+                    start,
+                    end,
+                    android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            } else {
+                // Это пункт списка
+                if (spannableBuilder.isNotEmpty()) {
+                    spannableBuilder.append("\n")
+                }
+
+                val start = spannableBuilder.length
+
+                // "  •  " создает визуальный сдвиг вправо перед точкой
+                val bulletPrefix = "  •  "
+                spannableBuilder.append("$bulletPrefix$cleanLine")
+                val end = spannableBuilder.length
+
+                // Настраиваем отступы для переноса строк
+                // first: 0 (префикс уже в строке)
+                // rest: 44px — это ширина "  •  " для шрифта 16sp, чтобы текст был ровно друг под другом
+                val leadingMarginInPx = 44
+
+                spannableBuilder.setSpan(
+                    android.text.style.LeadingMarginSpan.Standard(0, leadingMarginInPx),
+                    start,
+                    end,
+                    android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            }
+        }
+
+        return spannableBuilder
     }
 
     private fun formatSalary(salary: ru.practicum.android.diploma.feature.vacancy.domain.model.Salary): String {

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
@@ -1,6 +1,9 @@
 package ru.practicum.android.diploma.feature.vacancy.ui
 
 import android.os.Bundle
+import android.telephony.PhoneNumberUtils
+import android.text.Html
+import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
@@ -8,16 +11,27 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
+import com.bumptech.glide.Glide
 import com.google.android.material.textview.MaterialTextView
+import org.koin.androidx.viewmodel.ext.android.viewModel
 import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentVacancyBinding
+import ru.practicum.android.diploma.feature.vacancy.domain.model.VacancyDetail
+import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyState
+import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyViewModel
 import ru.practicum.android.diploma.feature.vacancy.ui.model.PhoneInfo
 import ru.practicum.android.diploma.util.fromDpToPx
 
 class VacancyFragment : Fragment() {
 
+    private val vacancyViewModel by viewModel<VacancyViewModel>()
+
     private var _binding: FragmentVacancyBinding? = null
     private val binding get() = _binding!!
+
+    private lateinit var contentVacancy: VacancyDetail
+
+
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -30,17 +44,218 @@ class VacancyFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        onPhoneInfoReceived(
-            listOf(
-                PhoneInfo("Комментарий", "89123456789"),
-                PhoneInfo(null, "89123456789")
-            )
-        )
+
+        binding.back.setOnClickListener {
+            requireActivity().supportFragmentManager.popBackStack()
+        }
+
+        val idTest = "026e3822-7106-4332-a39e-35e6dadd6936"
+        vacancyViewModel.getVacancyDetail(idTest)
+        vacancyViewModel.observeVacancyDetail().observe(viewLifecycleOwner) {
+            render(it)
+            Log.d("VacancyFragment", "onViewCreated: $it")
+        }
+
+        binding.share.setOnClickListener {
+            vacancyViewModel.sendVacancyViaMessenger(contentVacancy.url!!)
+
+        }
+
+
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun render(state: VacancyState) {
+        when (state) {
+            is VacancyState.Content -> showContent(state)
+            is VacancyState.Error -> showError(state)
+            is VacancyState.Loading -> showLoading()
+        }
+    }
+
+    private fun showContent(content: VacancyState.Content) {
+        val vacancy = content.content
+        contentVacancy = content.content
+        with(binding) {
+            // 1. Управление видимостью основных экранов
+            progressBar.visibility = View.GONE
+            vacancyLayout.visibility = View.VISIBLE
+            serverError.visibility = View.GONE
+            noInternetPlaceHolder.visibility = View.GONE
+
+            // Скрываем плейсхолдеры ошибок (если они в отдельных FrameLayout без ID,
+            // обычно они управляются через VacancyState.Error)
+
+            // 2. Основная информация
+            vacancyName.text = vacancy.name
+            vacancySalary.text = formatSalary(vacancy.salary!!)
+
+            // 3. Блок работодателя
+            employerName.text = vacancy.employer?.name
+            // Используем город из address, если нет - из area
+            regionCity.text = vacancy.address?.city ?: vacancy.area?.name
+
+            Glide.with(requireContext())
+                .load(vacancy.employer?.logo)
+                .placeholder(R.drawable.ic_placeholder)
+                .into(employerLogo)
+
+            // 4. Опыт и график
+            requiredExperience.text = vacancy.experience?.name
+            val scheduleText = "${vacancy.employment?.name}, ${vacancy.schedule?.name}"
+            employmentSchedule.text = scheduleText
+
+            // 5. Описание (с поддержкой HTML-тегов)
+
+
+            val rawDescription = vacancy.description
+
+            val formattedHtml = rawDescription?.let { raw ->
+                val blocks = raw.split("\n\n")
+                val result = StringBuilder()
+
+                blocks.forEachIndexed { index, block ->
+                    val lines = block.split("\n").map { it.trim() }.filter { it.isNotBlank() }
+                    if (lines.isEmpty()) return@forEachIndexed
+
+                    val firstLine = lines[0]
+                    // Универсальный заголовок: оканчивается на ":" или короткая строка
+                    val isHeader = firstLine.endsWith(":")
+
+                    // Добавляем лишний перенос перед заголовком, если это не самый первый блок
+                    if (isHeader && index > 0) {
+                        result.append("<br><br>")
+                    } else if (index > 0) {
+                        result.append("<br>")
+                    }
+
+                    if (isHeader) {
+                        result.append("<strong>$firstLine</strong>")
+                        if (lines.size > 1) {
+                            val listItems = lines.drop(1).joinToString("<br>") { line ->
+                                "&nbsp;&nbsp;•&nbsp;${line.removePrefix("-").removePrefix("•").trim()}"
+                            }
+                            result.append("<br>$listItems")
+                        }
+                    } else {
+                        if (lines.size > 1) {
+                            result.append(lines.joinToString("<br>") { line ->
+                                "&nbsp;&nbsp;•&nbsp;${line.removePrefix("-").removePrefix("•").trim()}"
+                            })
+                        } else {
+                            result.append(firstLine)
+                        }
+                    }
+                }
+                result.toString()
+            }
+
+            binding.vacancyDescription.text = Html.fromHtml(formattedHtml, Html.FROM_HTML_MODE_LEGACY)
+
+
+            // 6. Ключевые навыки (используем skillsGroup для управления видимостью)
+            if (vacancy.skills.isNullOrEmpty()) {
+                skillsGroup.visibility = View.GONE
+            } else {
+                skillsGroup.visibility = View.VISIBLE
+                // Форматируем список навыков с буллитами
+                vacancySkills.text = vacancy.skills.joinToString("\n") { "• $it" }
+            }
+
+            // 7. Контакты (используем contactGroup)
+            val contacts = vacancy.contacts
+            if (contacts == null || (contacts.name.isNullOrEmpty() && contacts.email.isNullOrEmpty() && contacts.phones!!.isEmpty())) {
+                contactGroup.visibility = View.GONE
+            } else {
+                contactGroup.visibility = View.VISIBLE
+
+                // Имя контактного лица
+                if (!contacts.name.isNullOrEmpty()) {
+                    vacancyContactName.text = contacts.name
+                    vacancyContactName.visibility = View.VISIBLE
+                } else {
+                    vacancyContactName.visibility = View.GONE
+                }
+
+                // Email
+                if (!contacts.email.isNullOrEmpty()) {
+                    vacancyContactEmail.text = contacts.email
+                    vacancyContactEmail.visibility = View.VISIBLE
+                    vacancyContactEmail.setOnClickListener {
+                        vacancyViewModel.selectEmailClientAndSend(contacts.email)
+                    }
+                } else {
+                    vacancyContactEmail.visibility = View.GONE
+                }
+
+                // Обработка телефонов (если у вас есть логика отрисовки списка телефонов)
+                if (contacts.phones!!.isNotEmpty()) {
+                    val phoneInfos = contacts.phones.map {
+                        PhoneInfo(it.comment, it.formatted!!)
+                    }
+                    onPhoneInfoReceived(phoneInfos)
+                }
+            }
+        }
+    }
+
+    private fun formatSalary(salary: ru.practicum.android.diploma.feature.vacancy.domain.model.Salary): String {
+        if (salary == null || (salary.from == null && salary.to == null)) {
+            return getString(R.string.salary_not_specified)
+        }
+
+        val text = StringBuilder()
+
+        // Используем ваш метод formatNumber для разделения разрядов пробелами
+        salary.from?.let {
+            text.append("от ${formatNumber(it)} ")
+        }
+        salary.to?.let {
+            text.append("до ${formatNumber(it)} ")
+        }
+
+        val currencySymbol = when (salary.currency) {
+            "AZN" -> "₼"
+            "BYR" -> "Br"
+            "EUR" -> "€"
+            "GEL" -> "₾"
+            "KGS" -> "с"
+            "KZT" -> "₸"
+            "RUR" -> "₽"
+            "UAH" -> "₴"
+            "USD" -> "$"
+            "UZS" -> "so'm"
+            else -> salary.currency
+        }
+        text.append(currencySymbol)
+
+        return text.toString()
+    }
+
+    private fun formatNumber(number: Int): String {
+        return java.text.DecimalFormat("#,###").format(number).replace(",", " ")
+    }
+
+    private fun showError(error: VacancyState.Error) {
+        binding.progressBar.visibility = View.GONE
+        if (error.errorMessage == getString(R.string.no_internet)) {
+            binding.noInternetPlaceHolder.visibility = View.VISIBLE
+            binding.serverError.visibility = View.GONE
+            binding.vacancyLayout.visibility = View.GONE
+        }else{
+            binding.noInternetPlaceHolder.visibility = View.GONE
+            binding.serverError.visibility = View.VISIBLE
+            binding.vacancyLayout.visibility = View.GONE
+        }
+    }
+
+    private fun showLoading() {
+        binding.progressBar.visibility = View.VISIBLE
+        binding.vacancyLayout.visibility = View.GONE
     }
 
     /**
@@ -57,7 +272,7 @@ class VacancyFragment : Fragment() {
                     )
                 }
                 val phoneTextView = MaterialTextView(getPhoneContextThemeWrapper())
-                phoneTextView.setOnClickListener { /* нажатие на номер телефона */ }
+                phoneTextView.setOnClickListener { vacancyViewModel.showCallAppsAndDial(phone.phone) }
                 upperId = initPhoneView(
                     phoneTextView, upperId, phone.phone
                 )
@@ -102,6 +317,7 @@ class VacancyFragment : Fragment() {
         requireContext(),
         R.style.VacancyContactHighlightTextViewStyle
     )
+
     private fun getPhoneCommentContextThemeWrapper() =
         ContextThemeWrapper(requireContext(), R.style.VacancyDetailsSingleTextViewStyle)
 

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyFragment.kt
@@ -60,8 +60,6 @@ class VacancyFragment : Fragment() {
             vacancyViewModel.sendVacancyViaMessenger(contentVacancy.url!!)
 
         }
-
-
     }
 
     override fun onDestroyView() {
@@ -81,22 +79,17 @@ class VacancyFragment : Fragment() {
         val vacancy = content.content
         contentVacancy = content.content
         with(binding) {
-            // 1. Управление видимостью основных экранов
+            share.visibility = View.VISIBLE
+            addToFavorites.visibility = View.VISIBLE
             progressBar.visibility = View.GONE
             vacancyLayout.visibility = View.VISIBLE
             serverError.visibility = View.GONE
             noInternetPlaceHolder.visibility = View.GONE
 
-            // Скрываем плейсхолдеры ошибок (если они в отдельных FrameLayout без ID,
-            // обычно они управляются через VacancyState.Error)
-
-            // 2. Основная информация
             vacancyName.text = vacancy.name
             vacancySalary.text = formatSalary(vacancy.salary!!)
 
-            // 3. Блок работодателя
             employerName.text = vacancy.employer?.name
-            // Используем город из address, если нет - из area
             regionCity.text = vacancy.address?.city ?: vacancy.area?.name
 
             Glide.with(requireContext())
@@ -104,36 +97,27 @@ class VacancyFragment : Fragment() {
                 .placeholder(R.drawable.ic_placeholder)
                 .into(employerLogo)
 
-            // 4. Опыт и график
             requiredExperience.text = vacancy.experience?.name
             val scheduleText = "${vacancy.employment?.name}, ${vacancy.schedule?.name}"
             employmentSchedule.text = scheduleText
 
-            // 5. Описание (с поддержкой HTML-тегов)
-
-
             val rawDescription = vacancy.description
+            binding.vacancyDescription.text = rawDescription
 
-            binding.vacancyDescription.text = formatRawDescription(rawDescription)
 
-
-            // 6. Ключевые навыки (используем skillsGroup для управления видимостью)
             if (vacancy.skills.isNullOrEmpty()) {
                 skillsGroup.visibility = View.GONE
             } else {
                 skillsGroup.visibility = View.VISIBLE
-                // Форматируем список навыков с буллитами
-                vacancySkills.text = vacancy.skills.joinToString("\n") { "• $it" }
+                vacancySkills.text = vacancy.skills.joinToString("\n") { " • $it" }
             }
 
-            // 7. Контакты (используем contactGroup)
             val contacts = vacancy.contacts
             if (contacts == null || (contacts.name.isNullOrEmpty() && contacts.email.isNullOrEmpty() && contacts.phones!!.isEmpty())) {
                 contactGroup.visibility = View.GONE
             } else {
                 contactGroup.visibility = View.VISIBLE
 
-                // Имя контактного лица
                 if (!contacts.name.isNullOrEmpty()) {
                     vacancyContactName.text = contacts.name
                     vacancyContactName.visibility = View.VISIBLE
@@ -141,7 +125,6 @@ class VacancyFragment : Fragment() {
                     vacancyContactName.visibility = View.GONE
                 }
 
-                // Email
                 if (!contacts.email.isNullOrEmpty()) {
                     vacancyContactEmail.text = contacts.email
                     vacancyContactEmail.visibility = View.VISIBLE
@@ -152,7 +135,6 @@ class VacancyFragment : Fragment() {
                     vacancyContactEmail.visibility = View.GONE
                 }
 
-                // Обработка телефонов (если у вас есть логика отрисовки списка телефонов)
                 if (contacts.phones!!.isNotEmpty()) {
                     val phoneInfos = contacts.phones.map {
                         PhoneInfo(it.comment, it.formatted!!)
@@ -161,76 +143,6 @@ class VacancyFragment : Fragment() {
                 }
             }
         }
-    }
-
-    private fun formatRawDescription(rawText: String?): CharSequence {
-        if (rawText.isNullOrBlank()) return ""
-
-        val spannableBuilder = android.text.SpannableStringBuilder()
-
-        // Разделяем на строки и очищаем от лишних пробелов
-        val lines = rawText.split("\n")
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
-
-        lines.forEach { line ->
-            // Очищаем строку от стандартных маркеров списков
-            val cleanLine = line.removePrefix("-").removePrefix("•").removePrefix("*").trim()
-
-            // Критерии заголовка (короткая строка, двоеточие в конце или отсутствие знаков препинания)
-            val isHeader = line.endsWith(":") || (
-                line.length < 30 &&
-                    !line.endsWith(".") &&
-                    !line.endsWith(";") &&
-                    !line.contains(",")
-                )
-
-            if (isHeader) {
-                // Убираем двоеточие в конце заголовка, если оно есть
-                val headerTitle = cleanLine.removeSuffix(":")
-
-                if (spannableBuilder.isNotEmpty()) {
-                    spannableBuilder.append("\n\n")
-                }
-                val start = spannableBuilder.length
-                spannableBuilder.append(headerTitle)
-                val end = spannableBuilder.length
-
-                // Жирный шрифт для заголовка
-                spannableBuilder.setSpan(
-                    android.text.style.StyleSpan(android.graphics.Typeface.BOLD),
-                    start,
-                    end,
-                    android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-            } else {
-                // Это пункт списка
-                if (spannableBuilder.isNotEmpty()) {
-                    spannableBuilder.append("\n")
-                }
-
-                val start = spannableBuilder.length
-
-                // "  •  " создает визуальный сдвиг вправо перед точкой
-                val bulletPrefix = "  •  "
-                spannableBuilder.append("$bulletPrefix$cleanLine")
-                val end = spannableBuilder.length
-
-                // Настраиваем отступы для переноса строк
-                // first: 0 (префикс уже в строке)
-                // rest: 44px — это ширина "  •  " для шрифта 16sp, чтобы текст был ровно друг под другом
-                val leadingMarginInPx = 44
-
-                spannableBuilder.setSpan(
-                    android.text.style.LeadingMarginSpan.Standard(0, leadingMarginInPx),
-                    start,
-                    end,
-                    android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-            }
-        }
-
-        return spannableBuilder
     }
 
     private fun formatSalary(salary: ru.practicum.android.diploma.feature.vacancy.domain.model.Salary): String {
@@ -273,10 +185,14 @@ class VacancyFragment : Fragment() {
     private fun showError(error: VacancyState.Error) {
         binding.progressBar.visibility = View.GONE
         if (error.errorMessage == getString(R.string.no_internet)) {
+            binding.share.visibility = View.GONE
+            binding.addToFavorites.visibility = View.GONE
             binding.noInternetPlaceHolder.visibility = View.VISIBLE
             binding.serverError.visibility = View.GONE
             binding.vacancyLayout.visibility = View.GONE
         }else{
+            binding.share.visibility = View.GONE
+            binding.addToFavorites.visibility = View.GONE
             binding.noInternetPlaceHolder.visibility = View.GONE
             binding.serverError.visibility = View.VISIBLE
             binding.vacancyLayout.visibility = View.GONE

--- a/app/src/main/java/ru/practicum/android/diploma/util/ui/DescriptionFormatterVacancy.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/util/ui/DescriptionFormatterVacancy.kt
@@ -1,0 +1,8 @@
+package ru.practicum.android.diploma.util.ui
+
+class DescriptionFormatterVacancy(private val description: String?) {
+    fun format(): String {
+        // нужна логика форматирования?
+        return description ?: ""
+    }
+}

--- a/app/src/main/java/ru/practicum/android/diploma/util/ui/SalaryFormatterVacancy.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/util/ui/SalaryFormatterVacancy.kt
@@ -2,10 +2,10 @@ package ru.practicum.android.diploma.util.ui
 
 import android.content.Context
 import ru.practicum.android.diploma.R
-import ru.practicum.android.diploma.feature.search.domain.model.Salary
+import ru.practicum.android.diploma.feature.vacancy.domain.model.Salary
 import ru.practicum.android.diploma.util.digitFormat
 
-class SalaryFormatter(private val salary: Salary?, private val context: Context) {
+class SalaryFormatterVacancy(private val salary: Salary?, private val context: Context) {
     private val currency: String by lazy {
         val currencySymbol = currencyMap[salary?.currency] ?: -1
         if (currencySymbol != -1) " " + context.getString(currencySymbol) else ""

--- a/app/src/main/res/layout/fragment_vacancy.xml
+++ b/app/src/main/res/layout/fragment_vacancy.xml
@@ -285,6 +285,7 @@
     </ScrollView>
 
     <FrameLayout
+        android:id="@+id/placeHolderForEmpty"
         style="@style/VacancyErrorFrameLayoutStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -298,6 +299,7 @@
             android:src="@drawable/img_job_unavailable" />
 
         <TextView
+            android:id="@+id/emptyTv"
             style="@style/VacancyErrorTextViewStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_vacancy.xml
+++ b/app/src/main/res/layout/fragment_vacancy.xml
@@ -125,7 +125,6 @@
                     android:layout_width="@dimen/company_logotype_size"
                     android:layout_height="@dimen/company_logotype_size"
                     android:background="@null"
-                    android:scaleType="centerCrop"
                     android:src="@drawable/ic_placeholder"
                     app:shapeAppearance="@style/roundedImageView" />
 
@@ -305,6 +304,7 @@
     </FrameLayout>
 
     <FrameLayout
+        android:id="@+id/serverError"
         style="@style/VacancyErrorFrameLayoutStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -325,6 +325,7 @@
     </FrameLayout>
 
     <FrameLayout
+        android:id="@+id/noInternetPlaceHolder"
         style="@style/VacancyErrorFrameLayoutStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -345,6 +346,7 @@
     </FrameLayout>
 
     <ProgressBar
+        android:id="@+id/progressBar"
         android:layout_width="@dimen/progress_bar_size"
         android:layout_height="@dimen/progress_bar_size"
         android:layout_gravity="center"

--- a/app/src/main/res/layout/fragment_vacancy.xml
+++ b/app/src/main/res/layout/fragment_vacancy.xml
@@ -64,7 +64,8 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/vacancy_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/padding_8">
 
             <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/start_16_line"

--- a/app/src/main/res/navigation/main_navigation_graph.xml
+++ b/app/src/main/res/navigation/main_navigation_graph.xml
@@ -21,7 +21,8 @@
         tools:layout="@layout/fragment_search" >
         <action
             android:id="@+id/action_searchFragment_to_vacancyFragment"
-            app:destination="@id/vacancyFragment" />
+            app:destination="@id/vacancyFragment">
+            </action>
         <action
             android:id="@+id/action_searchFragment_to_filterSettingsFragment"
             app:destination="@id/filterSettingsFragment" />
@@ -35,7 +36,11 @@
         android:id="@+id/vacancyFragment"
         android:name="ru.practicum.android.diploma.feature.vacancy.ui.VacancyFragment"
         android:label="fragment_vacancy"
-        tools:layout="@layout/fragment_vacancy" />
+        tools:layout="@layout/fragment_vacancy">
+        <argument
+            android:name="vacancyId"
+            app:argType="string"/>
+    </fragment>
     <fragment
         android:id="@+id/filterSettingsFragment"
         android:name="ru.practicum.android.diploma.feature.filter.ui.FilterSettingsFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="key_skills">Ключевые навыки</string>
     <string name="vacancy_not_found">Вакансия не найдена или\nудалена</string>
     <string name="contacts">Контакты</string>
+    <string name="salary_not_specified">Зарплата не указана</string>
 
     <!-- Fragment "Избранное" -->
     <string name="favorites">Избранное</string>


### PR DESCRIPTION
Есть небольшая проблема: описание вакансии с сервера приходит без html тегов как на оригинальном api HH, поэтому не получается отформатировать текст, так чтобы он выглядел как на макете, потому что логика пунктов и подпунктов разделена достаточно рандомно через enter (\n) , может у вас получится придумать функцию форматирования текста DescriptionFormatterVacancy 
<img width="894" height="294" alt="image" src="https://github.com/user-attachments/assets/3d19079d-609a-41d7-aaa6-65fb21eb7027" />
 Также пришлось продублировать функцию форматирования зп, чтобы работали с разными дата классами домейн модели поиска и детали вакансии, ну это чуть позже пофиксим
