### PR TITLE
Исправление обновления списка вакансий

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/VacanciesAdapter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/VacanciesAdapter.kt
@@ -21,7 +21,7 @@ class VacanciesAdapter(
      */
     fun submitList(newList: List<Vacancy>) {
         val diff = DiffUtil.calculateDiff(VacancyDiffCallback(vacancies, newList))
-        vacancies = newList
+        vacancies = newList.toList()
         diff.dispatchUpdatesTo(this)
     }
 


### PR DESCRIPTION
При новом запросе на экране поиска вакансий старые результаты оставались и не перерисовывались.
DiffUtil неправильно отрабатывал, получая одинаковые списки с результатом.
Причина была в присваивании старому списку ссылки, а не значения нового